### PR TITLE
feat(cb2-7228): prevent duplicate VRMs in EVL view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .idea
 liquibase.properties
-mysql-connector-java-*
+mysql-connector-j*

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -23,11 +23,11 @@ FROM (
 					vrm_trm
 			) SubQ ON SubQ.id = t.vehicle_id
 		WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-                        AND (
-                            t.certificateNumber IS NOT NULL
-                            AND t.certificateNumber != ''
-                            AND NOT LOCATE(' ', t.certificateNumber) > 0
-                        )
+            AND (
+                t.certificateNumber IS NOT NULL
+                AND t.certificateNumber != ''
+                AND NOT LOCATE(' ', t.certificateNumber) > 0
+            )
 			AND tt.testTypeClassification = 'Annual With Certificate'
 		GROUP BY SubQ.vrm_trm,
 			t.certificateNumber,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -2,11 +2,9 @@
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
 CREATE OR REPLACE VIEW evl_view AS
 SELECT testExpiryDate, vrm_trm, certificateNumber 
-FROM 
-(
+FROM (
 	SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) as row_number_over_partition, @prev:=vrm_trm, @rn:=@rn+1 AS rn
-	FROM
-	( 
+	FROM ( 
 		SELECT MAX(testExpiryDate) AS testExpiryDate,
 			SubQ.vrm_trm,
 			t.certificateNumber,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,28 +1,39 @@
 --liquibase formatted sql
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
 CREATE OR REPLACE VIEW evl_view AS
-SELECT MAX(testExpiryDate) AS testExpiryDate,
-    SubQ.vrm_trm,
-    t.certificateNumber
-FROM test_result t
-    JOIN test_type tt ON t.test_type_id = tt.id
-    JOIN (
-        SELECT MAX(createdAt),
-            id,
-            vrm_trm
-        FROM vehicle
-        WHERE LENGTH(vrm_trm) < 8
-            AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-            AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-        GROUP BY id,
-            vrm_trm
-    ) SubQ ON SubQ.id = t.vehicle_id
-WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-    AND (
-        t.certificateNumber IS NOT NULL
-        AND t.certificateNumber != ''
-        AND NOT LOCATE(' ', t.certificateNumber) > 0
-    )
-    AND tt.testTypeClassification = 'Annual With Certificate'
-GROUP BY SubQ.vrm_trm,
-    t.certificateNumber;
+SELECT testExpiryDate, vrm_trm, certificateNumber 
+FROM 
+(
+	SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) as count, @prev:=vrm_trm, @rn:=@rn+1 AS rn
+	FROM
+	( 
+		SELECT MAX(testExpiryDate) AS testExpiryDate,
+			SubQ.vrm_trm,
+			t.certificateNumber,
+			t.testTypeEndTimeStamp
+		FROM test_result as t
+			JOIN test_type tt ON t.test_type_id = tt.id
+			JOIN (
+				SELECT MAX(createdAt),
+					id,
+					vrm_trm
+				FROM vehicle
+				WHERE LENGTH(vrm_trm) < 8
+					AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+					AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+				GROUP BY id,
+					vrm_trm
+			) SubQ ON SubQ.id = t.vehicle_id
+		WHERE (
+				t.certificateNumber IS NOT NULL
+				AND t.certificateNumber != ''
+				AND NOT LOCATE(' ', t.certificateNumber) > 0
+			)
+			AND tt.testTypeClassification = 'Annual With Certificate'
+		GROUP BY SubQ.vrm_trm,
+			t.certificateNumber,
+			t.testTypeEndTimeStamp
+		ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc
+	) as SubQ2
+) as SubQ3
+WHERE count = 0

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -23,11 +23,11 @@ FROM (
 					vrm_trm
 			) SubQ ON SubQ.id = t.vehicle_id
 		WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-            AND (
-                t.certificateNumber IS NOT NULL
-                AND t.certificateNumber != ''
-                AND NOT LOCATE(' ', t.certificateNumber) > 0
-            )
+                AND (
+                    t.certificateNumber IS NOT NULL
+                    AND t.certificateNumber != ''
+                    AND NOT LOCATE(' ', t.certificateNumber) > 0
+                )
 			AND tt.testTypeClassification = 'Annual With Certificate'
 		GROUP BY SubQ.vrm_trm,
 			t.certificateNumber,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -3,63 +3,63 @@
 -- Refactor to use ROW_NUMBER() OVER(PARTITION ...) ONCE MIGRATED TO MYSQL 8.0+
 CREATE OR REPLACE VIEW evl_view AS 
 SELECT MAX(testExpiryDate) AS testExpiryDate,
-	SubQ.vrm_trm,
-	t.certificateNumber
-FROM test_result as t
-	JOIN test_type tt ON t.test_type_id = tt.id
-	JOIN (
-		SELECT MAX(createdAt),
-			id,
-			vrm_trm
-		FROM vehicle
-		WHERE LENGTH(vrm_trm) < 8
-			AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-			AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-		GROUP BY id,
-			vrm_trm
-	) SubQ ON SubQ.id = t.vehicle_id
+    SubQ.vrm_trm,
+    t.certificateNumber
+FROM test_result t
+    JOIN test_type tt ON t.test_type_id = tt.id
+    JOIN (
+        SELECT MAX(createdAt),
+            id,
+            vrm_trm
+        FROM vehicle
+        WHERE LENGTH(vrm_trm) < 8
+            AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+            AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+        GROUP BY id,
+            vrm_trm
+    ) SubQ ON SubQ.id = t.vehicle_id 
 WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-	AND (
-		t.certificateNumber IS NOT NULL
-		AND t.certificateNumber != ''
-		AND NOT LOCATE(' ', t.certificateNumber) > 0
-	)
-	AND tt.testTypeClassification = 'Annual With Certificate'
-	AND NOT EXISTS (
-		SELECT 1 FROM test_result
-		WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
-	)
-	AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
-		SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
-			FROM test_result tr
-			JOIN (
-				SELECT MAX(createdAt),
-					id,
-					vrm_trm
-				FROM vehicle
-				WHERE LENGTH(vrm_trm) < 8
-					AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-					AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-				GROUP BY id,
-					vrm_trm
-			) SubQ ON SubQ.id = tr.vehicle_id
-			WHERE (vrm_trm, testExpiryDate) IN (
-				SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
-				FROM test_result t
-				JOIN (
-					SELECT MAX(createdAt),
-						id,
-						vrm_trm
-					FROM vehicle
-					WHERE LENGTH(vrm_trm) < 8
-						AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-						AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-					GROUP BY id,
-						vrm_trm
-				) SubQ ON SubQ.id = t.vehicle_id
-				GROUP BY vrm_trm
-			)
-		GROUP BY vrm_trm, testExpiryDate
-	)	
+    AND (
+        t.certificateNumber IS NOT NULL
+        AND t.certificateNumber != ''
+        AND NOT LOCATE(' ', t.certificateNumber) > 0
+    )
+    AND tt.testTypeClassification = 'Annual With Certificate'
+    AND NOT EXISTS (
+        SELECT 1 FROM test_result
+        WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
+    )
+    AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
+        SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
+            FROM test_result tr
+            JOIN (
+                SELECT MAX(createdAt),
+                    id,
+                    vrm_trm
+                FROM vehicle
+                WHERE LENGTH(vrm_trm) < 8
+                    AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                    AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+                GROUP BY id,
+                    vrm_trm
+            ) SubQ ON SubQ.id = tr.vehicle_id
+            WHERE (vrm_trm, testExpiryDate) IN (
+                SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
+                FROM test_result t
+                JOIN (
+                    SELECT MAX(createdAt),
+                        id,
+                        vrm_trm
+                    FROM vehicle
+                    WHERE LENGTH(vrm_trm) < 8
+                        AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                        AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+                    GROUP BY id,
+                        vrm_trm
+                ) SubQ ON SubQ.id = t.vehicle_id
+                GROUP BY vrm_trm
+            )
+        GROUP BY vrm_trm, testExpiryDate
+    )    
 GROUP BY SubQ.vrm_trm,
-	t.certificateNumber
+    t.certificateNumber

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -22,11 +22,12 @@ FROM (
 				GROUP BY id,
 					vrm_trm
 			) SubQ ON SubQ.id = t.vehicle_id
-		WHERE (
-				t.certificateNumber IS NOT NULL
-				AND t.certificateNumber != ''
-				AND NOT LOCATE(' ', t.certificateNumber) > 0
-			)
+		WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
+            AND (
+                t.certificateNumber IS NOT NULL
+                AND t.certificateNumber != ''
+                AND NOT LOCATE(' ', t.certificateNumber) > 0
+            )
 			AND tt.testTypeClassification = 'Annual With Certificate'
 		GROUP BY SubQ.vrm_trm,
 			t.certificateNumber,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,16 +1,37 @@
 --liquibase formatted sql
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
-CREATE OR REPLACE VIEW evl_view AS
-SELECT testExpiryDate, vrm_trm, certificateNumber 
-FROM (
-	SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) as row_number_over_partition, @prev:=vrm_trm, @rn:=@rn+1 AS rn
-	FROM ( 
-		SELECT MAX(testExpiryDate) AS testExpiryDate,
-			SubQ.vrm_trm,
-			t.certificateNumber,
-			t.testTypeEndTimeStamp
-		FROM test_result as t
-			JOIN test_type tt ON t.test_type_id = tt.id
+-- Refactor to use ROW_NUMBER() OVER(PARTITION ...) ONCE MIGRATED TO MYSQL 8.0+
+CREATE OR REPLACE VIEW evl_view AS 
+SELECT MAX(testExpiryDate) AS testExpiryDate,
+	SubQ.vrm_trm,
+	t.certificateNumber
+FROM test_result as t
+	JOIN test_type tt ON t.test_type_id = tt.id
+	JOIN (
+		SELECT MAX(createdAt),
+			id,
+			vrm_trm
+		FROM vehicle
+		WHERE LENGTH(vrm_trm) < 8
+			AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+			AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+		GROUP BY id,
+			vrm_trm
+	) SubQ ON SubQ.id = t.vehicle_id
+WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
+                    AND (
+                        t.certificateNumber IS NOT NULL
+                        AND t.certificateNumber != ''
+                        AND NOT LOCATE(' ', t.certificateNumber) > 0
+                    )
+			AND tt.testTypeClassification = 'Annual With Certificate'
+    AND NOT EXISTS (
+		SELECT 1 FROM test_result
+		WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
+    )
+	AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
+		SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
+			FROM test_result tr
 			JOIN (
 				SELECT MAX(createdAt),
 					id,
@@ -21,18 +42,24 @@ FROM (
 					AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
 				GROUP BY id,
 					vrm_trm
-			) SubQ ON SubQ.id = t.vehicle_id
-		WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-            AND (
-                t.certificateNumber IS NOT NULL
-                AND t.certificateNumber != ''
-                AND NOT LOCATE(' ', t.certificateNumber) > 0
-            )
-			AND tt.testTypeClassification = 'Annual With Certificate'
-		GROUP BY SubQ.vrm_trm,
-			t.certificateNumber,
-			t.testTypeEndTimeStamp
-		ORDER BY vrm_trm, testExpiryDate DESC, t.testTypeEndTimeStamp DESC
-	) as SubQ2
-) as SubQ3
-WHERE row_number_over_partition = 0
+			) SubQ ON SubQ.id = tr.vehicle_id
+			WHERE (vrm_trm, testExpiryDate) IN (
+				SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
+				 FROM test_result t
+				 JOIN (
+					SELECT MAX(createdAt),
+						id,
+						vrm_trm
+					FROM vehicle
+					WHERE LENGTH(vrm_trm) < 8
+						AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+						AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+					GROUP BY id,
+						vrm_trm
+				) SubQ ON SubQ.id = t.vehicle_id
+				GROUP BY vrm_trm
+		    )
+		GROUP BY vrm_trm, testExpiryDate
+	)	
+GROUP BY SubQ.vrm_trm,
+	t.certificateNumber

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -23,11 +23,11 @@ FROM (
 					vrm_trm
 			) SubQ ON SubQ.id = t.vehicle_id
 		WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-                AND (
-                    t.certificateNumber IS NOT NULL
-                    AND t.certificateNumber != ''
-                    AND NOT LOCATE(' ', t.certificateNumber) > 0
-                )
+                    AND (
+                        t.certificateNumber IS NOT NULL
+                        AND t.certificateNumber != ''
+                        AND NOT LOCATE(' ', t.certificateNumber) > 0
+                    )
 			AND tt.testTypeClassification = 'Annual With Certificate'
 		GROUP BY SubQ.vrm_trm,
 			t.certificateNumber,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,4 +1,4 @@
---liquibase formatted sqlW01B4174
+--liquibase formatted sql
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
 -- Refactor to use ROW_NUMBER() OVER(PARTITION ...) ONCE MIGRATED TO MYSQL 8.0+
 CREATE OR REPLACE VIEW evl_view AS 

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -17,7 +17,7 @@ FROM test_result t
             AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
         GROUP BY id,
             vrm_trm
-    ) SubQ ON SubQ.id = t.vehicle_id 
+    ) SubQ ON SubQ.id = t.vehicle_id
 WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
     AND (
         t.certificateNumber IS NOT NULL
@@ -62,4 +62,4 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
         GROUP BY vrm_trm, testExpiryDate
     )    
 GROUP BY SubQ.vrm_trm,
-    t.certificateNumber
+    t.certificateNumber;

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+--changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev runOnChange:true
 -- Refactor to use ROW_NUMBER() OVER(PARTITION ...) ONCE MIGRATED TO MYSQL 8.0+
 CREATE OR REPLACE VIEW evl_view AS 
 SELECT MAX(testExpiryDate) AS testExpiryDate,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,4 +1,4 @@
---liquibase formatted sql
+--liquibase formatted sqlW01B4174
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
 -- Refactor to use ROW_NUMBER() OVER(PARTITION ...) ONCE MIGRATED TO MYSQL 8.0+
 CREATE OR REPLACE VIEW evl_view AS 
@@ -19,47 +19,47 @@ FROM test_result as t
 			vrm_trm
 	) SubQ ON SubQ.id = t.vehicle_id
 WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-            AND (
-                t.certificateNumber IS NOT NULL
-                AND t.certificateNumber != ''
-                AND NOT LOCATE(' ', t.certificateNumber) > 0
-            )
-            AND tt.testTypeClassification = 'Annual With Certificate'
-            AND NOT EXISTS (
-                SELECT 1 FROM test_result
-                WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
-            )
-            AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
-                SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
-                    FROM test_result tr
-                    JOIN (
-                        SELECT MAX(createdAt),
-                            id,
-                            vrm_trm
-                        FROM vehicle
-                        WHERE LENGTH(vrm_trm) < 8
-                            AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-                            AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-                        GROUP BY id,
-                            vrm_trm
-                    ) SubQ ON SubQ.id = tr.vehicle_id
-                    WHERE (vrm_trm, testExpiryDate) IN (
-                        SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
-                        FROM test_result t
-                        JOIN (
-                            SELECT MAX(createdAt),
-                                id,
-                                vrm_trm
-                            FROM vehicle
-                            WHERE LENGTH(vrm_trm) < 8
-                                AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-                                AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-                            GROUP BY id,
-                                vrm_trm
-                        ) SubQ ON SubQ.id = t.vehicle_id
-                        GROUP BY vrm_trm
-                    )
-                GROUP BY vrm_trm, testExpiryDate
+	AND (
+		t.certificateNumber IS NOT NULL
+		AND t.certificateNumber != ''
+		AND NOT LOCATE(' ', t.certificateNumber) > 0
+	)
+	AND tt.testTypeClassification = 'Annual With Certificate'
+	AND NOT EXISTS (
+		SELECT 1 FROM test_result
+		WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
+	)
+	AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
+		SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
+			FROM test_result tr
+			JOIN (
+				SELECT MAX(createdAt),
+					id,
+					vrm_trm
+				FROM vehicle
+				WHERE LENGTH(vrm_trm) < 8
+					AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+					AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+				GROUP BY id,
+					vrm_trm
+			) SubQ ON SubQ.id = tr.vehicle_id
+			WHERE (vrm_trm, testExpiryDate) IN (
+				SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
+				FROM test_result t
+				JOIN (
+					SELECT MAX(createdAt),
+						id,
+						vrm_trm
+					FROM vehicle
+					WHERE LENGTH(vrm_trm) < 8
+						AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+						AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+					GROUP BY id,
+						vrm_trm
+				) SubQ ON SubQ.id = t.vehicle_id
+				GROUP BY vrm_trm
+			)
+		GROUP BY vrm_trm, testExpiryDate
 	)	
 GROUP BY SubQ.vrm_trm,
 	t.certificateNumber

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -4,7 +4,7 @@ CREATE OR REPLACE VIEW evl_view AS
 SELECT testExpiryDate, vrm_trm, certificateNumber 
 FROM 
 (
-	SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) as count, @prev:=vrm_trm, @rn:=@rn+1 AS rn
+	SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) as row_number_over_partition, @prev:=vrm_trm, @rn:=@rn+1 AS rn
 	FROM
 	( 
 		SELECT MAX(testExpiryDate) AS testExpiryDate,
@@ -36,4 +36,4 @@ FROM
 		ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc
 	) as SubQ2
 ) as SubQ3
-WHERE count = 0
+WHERE row_number_over_partition = 0

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -32,7 +32,7 @@ FROM (
 		GROUP BY SubQ.vrm_trm,
 			t.certificateNumber,
 			t.testTypeEndTimeStamp
-		ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc
+		ORDER BY vrm_trm, testExpiryDate DESC, t.testTypeEndTimeStamp DESC
 	) as SubQ2
 ) as SubQ3
 WHERE row_number_over_partition = 0

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -23,11 +23,11 @@ FROM (
 					vrm_trm
 			) SubQ ON SubQ.id = t.vehicle_id
 		WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-                    AND (
-                        t.certificateNumber IS NOT NULL
-                        AND t.certificateNumber != ''
-                        AND NOT LOCATE(' ', t.certificateNumber) > 0
-                    )
+                        AND (
+                            t.certificateNumber IS NOT NULL
+                            AND t.certificateNumber != ''
+                            AND NOT LOCATE(' ', t.certificateNumber) > 0
+                        )
 			AND tt.testTypeClassification = 'Annual With Certificate'
 		GROUP BY SubQ.vrm_trm,
 			t.certificateNumber,

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -19,47 +19,47 @@ FROM test_result as t
 			vrm_trm
 	) SubQ ON SubQ.id = t.vehicle_id
 WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-                    AND (
-                        t.certificateNumber IS NOT NULL
-                        AND t.certificateNumber != ''
-                        AND NOT LOCATE(' ', t.certificateNumber) > 0
+            AND (
+                t.certificateNumber IS NOT NULL
+                AND t.certificateNumber != ''
+                AND NOT LOCATE(' ', t.certificateNumber) > 0
+            )
+            AND tt.testTypeClassification = 'Annual With Certificate'
+            AND NOT EXISTS (
+                SELECT 1 FROM test_result
+                WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
+            )
+            AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
+                SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
+                    FROM test_result tr
+                    JOIN (
+                        SELECT MAX(createdAt),
+                            id,
+                            vrm_trm
+                        FROM vehicle
+                        WHERE LENGTH(vrm_trm) < 8
+                            AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                            AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+                        GROUP BY id,
+                            vrm_trm
+                    ) SubQ ON SubQ.id = tr.vehicle_id
+                    WHERE (vrm_trm, testExpiryDate) IN (
+                        SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
+                        FROM test_result t
+                        JOIN (
+                            SELECT MAX(createdAt),
+                                id,
+                                vrm_trm
+                            FROM vehicle
+                            WHERE LENGTH(vrm_trm) < 8
+                                AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                                AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+                            GROUP BY id,
+                                vrm_trm
+                        ) SubQ ON SubQ.id = t.vehicle_id
+                        GROUP BY vrm_trm
                     )
-			AND tt.testTypeClassification = 'Annual With Certificate'
-    AND NOT EXISTS (
-		SELECT 1 FROM test_result
-		WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
-    )
-	AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
-		SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
-			FROM test_result tr
-			JOIN (
-				SELECT MAX(createdAt),
-					id,
-					vrm_trm
-				FROM vehicle
-				WHERE LENGTH(vrm_trm) < 8
-					AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-					AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-				GROUP BY id,
-					vrm_trm
-			) SubQ ON SubQ.id = tr.vehicle_id
-			WHERE (vrm_trm, testExpiryDate) IN (
-				SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
-				 FROM test_result t
-				 JOIN (
-					SELECT MAX(createdAt),
-						id,
-						vrm_trm
-					FROM vehicle
-					WHERE LENGTH(vrm_trm) < 8
-						AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-						AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-					GROUP BY id,
-						vrm_trm
-				) SubQ ON SubQ.id = t.vehicle_id
-				GROUP BY vrm_trm
-		    )
-		GROUP BY vrm_trm, testExpiryDate
+                GROUP BY vrm_trm, testExpiryDate
 	)	
 GROUP BY SubQ.vrm_trm,
-	t.certificateNumber;
+	t.certificateNumber

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -62,4 +62,4 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
 		GROUP BY vrm_trm, testExpiryDate
 	)	
 GROUP BY SubQ.vrm_trm,
-	t.certificateNumber
+	t.certificateNumber;


### PR DESCRIPTION
## Description

The current implementation of the evl view can result in duplicate VRMs being sent, causing the file loading process to fail.

Due to these failures the following logic changes have to be made, if there are multiple VRMs:
- Select the test with the maximum expiry date,
- If there are still duplicate vrms, select the test with the maximum end date and time,
- If there are still duplicate vrms, select one test at random.

https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_build_nop/153/ after this change on a copy of develop

Related issue: [CB2-7228](https://dvsa.atlassian.net/browse/CB2-7228)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
