### PR TITLE
feature(cb2-7228), fix(cb2-7420): prevent duplicate vrms in evl file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .idea
 liquibase.properties
-mysql-connector-java-*
+mysql-connector-j*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .idea
 liquibase.properties
-mysql-connector-j*
+mysql-connector-java-*

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -25,5 +25,5 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
     )
     AND tt.testTypeClassification = 'Annual With Certificate'
 GROUP BY SubQ.vrm_trm,
-    t.certificateNumber;
-ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc
+    t.certificateNumber
+ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc;

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+--changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev runOnChange:true
 CREATE OR REPLACE VIEW evl_view AS
 SELECT MAX(testExpiryDate) AS testExpiryDate,
     SubQ.vrm_trm,
@@ -26,3 +26,4 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
     AND tt.testTypeClassification = 'Annual With Certificate'
 GROUP BY SubQ.vrm_trm,
     t.certificateNumber;
+ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,7 +1,6 @@
 --liquibase formatted sql
---changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev runOnChange:true
--- Refactor to use ROW_NUMBER() OVER(PARTITION ...) ONCE MIGRATED TO MYSQL 8.0+
-CREATE OR REPLACE VIEW evl_view AS 
+--changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+CREATE OR REPLACE VIEW evl_view AS
 SELECT MAX(testExpiryDate) AS testExpiryDate,
     SubQ.vrm_trm,
     t.certificateNumber
@@ -25,41 +24,5 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
         AND NOT LOCATE(' ', t.certificateNumber) > 0
     )
     AND tt.testTypeClassification = 'Annual With Certificate'
-    AND NOT EXISTS (
-        SELECT 1 FROM test_result
-        WHERE t.vehicle_id = test_result.vehicle_id AND t.certificateNumber < test_result.certificateNumber
-    )
-    AND (testExpiryDate, vrm_trm, testTypeEndTimestamp) IN (
-        SELECT DISTINCT testExpiryDate, vrm_trm, MAX(testTypeEndTimeStamp) AS testTypeEndTimeStamp
-            FROM test_result tr
-            JOIN (
-                SELECT MAX(createdAt),
-                    id,
-                    vrm_trm
-                FROM vehicle
-                WHERE LENGTH(vrm_trm) < 8
-                    AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-                    AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-                GROUP BY id,
-                    vrm_trm
-            ) SubQ ON SubQ.id = tr.vehicle_id
-            WHERE (vrm_trm, testExpiryDate) IN (
-                SELECT vrm_trm, MAX(t.testExpiryDate) AS testExpiryDate
-                FROM test_result t
-                JOIN (
-                    SELECT MAX(createdAt),
-                        id,
-                        vrm_trm
-                    FROM vehicle
-                    WHERE LENGTH(vrm_trm) < 8
-                        AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-                        AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-                    GROUP BY id,
-                        vrm_trm
-                ) SubQ ON SubQ.id = t.vehicle_id
-                GROUP BY vrm_trm
-            )
-        GROUP BY vrm_trm, testExpiryDate
-    )    
 GROUP BY SubQ.vrm_trm,
     t.certificateNumber;


### PR DESCRIPTION
## Description

This change essentially reverts https://github.com/dvsa/cvs-nop/pull/7, with a few extra changes (compared to before  https://github.com/dvsa/cvs-nop/pull/7), like ordering and running allowing to change the view through liquibase. This view will now be consumed as is from the database and the query will be updated in https://github.com/dvsa/cvs-svc-enquiry/pull/45 to remove the duplicates. This has to be done in the lambda to since MySQL 5.7 does not have the row number over partition function and views cannot use variables.

Related issues: 
- [CB2-7228](https://dvsa.atlassian.net/browse/CB2-7228)
- [CB2-7420](https://dvsa.atlassian.net/browse/CB2-7420)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
