### PR TITLE
CB2-7685: Workaround for missing insertId on upserts

### DIFF
--- a/sql/00000_base_database.sql
+++ b/sql/00000_base_database.sql
@@ -503,6 +503,7 @@ CREATE TABLE IF NOT EXISTS test_result
     `smokeTestKLimitApplied`            VARCHAR(100),
     `createdBy_Id`                      BIGINT UNSIGNED NOT NULL,
     `lastUpdatedBy_Id`                  BIGINT UNSIGNED NOT NULL,
+    `nopInsertedAt`                     DATETIME(3),
     `testtype_fingerprint`              VARCHAR(32) GENERATED ALWAYS AS (MD5(
                                         CONCAT_WS('|', IFNULL(`testNumber`, ''), IFNULL(`testTypeEndTimestamp`, '')))) STORED NOT NULL,
 
@@ -693,13 +694,14 @@ CREATE TABLE IF NOT EXISTS `testtype_version`
     `lastSeatbeltInstallationCheckDate` DATE,
     `seatbeltInstallationCheckDate`     TINYINT(1),
     `testResult`                        VARCHAR(9),
-    `reasonForAbandoning`               VARCHAR(45),
+    `reasonForAbandoning`               VARCHAR(420),
     `additionalNotesRecorded`           VARCHAR(500),
     `additionalCommentsForAbandon`      VARCHAR(500),
     `particulateTrapFitted`             VARCHAR(100),
     `particulateTrapSerialNumber`       VARCHAR(100),
     `modificationTypeUsed`              VARCHAR(100),
     `smokeTestKLimitApplied`            VARCHAR(100),
+    `nopInsertedAt`                     DATETIME(3),
     `testType_insert_ts`                DATETIME DEFAULT NOW(),
     PRIMARY KEY (`id`),
     

--- a/sql/00002_test_result_audit_test_type_version_trigger.sql
+++ b/sql/00002_test_result_audit_test_type_version_trigger.sql
@@ -36,7 +36,7 @@ CREATE TRIGGER check_tt_version AFTER UPDATE ON `test_result`
                 `testResult`, `reasonForAbandoning`, `additionalNotesRecorded`, 
                 `additionalCommentsForAbandon`, `particulateTrapFitted`, 
                 `particulateTrapSerialNumber`, `modificationTypeUsed`, 
-                `smokeTestKLimitApplied`)
+                `smokeTestKLimitApplied`, `nopInsertedAt`)
             VALUES
                 ( OLD.`id`, OLD.`vehicle_id`, OLD.`fuel_emission_id`,
                 OLD.`test_station_id`, OLD.`tester_id`, OLD.`preparer_id`, OLD.`vehicle_class_id`,
@@ -51,6 +51,6 @@ CREATE TRIGGER check_tt_version AFTER UPDATE ON `test_result`
                 OLD.`testResult`, OLD.`reasonForAbandoning`, OLD.`additionalNotesRecorded`, 
                 OLD.`additionalCommentsForAbandon`, OLD.`particulateTrapFitted`, 
                 OLD.`particulateTrapSerialNumber`, OLD.`modificationTypeUsed`, 
-                OLD.`smokeTestKLimitApplied`);
+                OLD.`smokeTestKLimitApplied`, OLD.`nopInsertedAt`);
         END IF;
 END;


### PR DESCRIPTION
## Description

The test_result table has a trigger that populates the testtype_version table. It has been found that it can affect the identity returned to the update store lambda.

The issue only arises when: 

- A result is processed for the second time and results in an update rather than an insert.
and
- The test_result does not differ in any anyway to the record being updated.

Related issue: [CB2-7685](https://dvsa.atlassian.net/browse/CB2-7685)
Related issue: [cvs-tsk-update-store/pull/62](https://github.com/dvsa/cvs-tsk-update-store/pull/62)

## Evidence of completion
In the absence of a fix or understanding of the behaviour, a workaround has been implemented which involves inserting a timestamp along with the rest of the test_result data.
### Before workaround
First upsert
![image](https://user-images.githubusercontent.com/13391709/222709314-2b2b75f3-0aa6-4e7e-a71f-59fe9a9b3087.png)
Second upsert
![image](https://user-images.githubusercontent.com/13391709/222709543-60f243e7-1125-452b-96c0-60fe7927e872.png)
### After workaround
First upsert
![image](https://user-images.githubusercontent.com/13391709/222710124-bd8de9fd-53e5-4cfe-be95-f2f2e44555b0.png)
Second upsert
![image](https://user-images.githubusercontent.com/13391709/222710385-05274082-d62c-4d8c-8944-84f54384f949.png)
Data in the database
![image](https://user-images.githubusercontent.com/13391709/222710327-200190ef-f5be-4839-be89-b3c024644c2f.png)

