### PR TITLE
feat(cb2-7789): remove cancelled tests from EVL and MOTH

### DIFF
--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -21,9 +21,9 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
     AND (
         t.certificateNumber IS NOT NULL
         AND t.certificateNumber != ''
-        AND t.testStatus != 'cancelled'
         AND NOT LOCATE(' ', t.certificateNumber) > 0
     )
+    AND t.testStatus != 'cancelled'
     AND tt.testTypeClassification = 'Annual With Certificate'
 GROUP BY SubQ.vrm_trm,
     t.certificateNumber

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -21,6 +21,7 @@ WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
     AND (
         t.certificateNumber IS NOT NULL
         AND t.certificateNumber != ''
+        AND t.testStatus != 'cancelled'
         AND NOT LOCATE(' ', t.certificateNumber) > 0
     )
     AND tt.testTypeClassification = 'Annual With Certificate'


### PR DESCRIPTION
## Description

Removes cancelled tests from EVL and MOTH

Related issue: [CB2-7789](https://dvsa.atlassian.net/browse/CB2-7789)

There currently is only one test in develop which is cancelled and in the allowed timeframe for EVL. We can see below it is being removed.

<img width="850" alt="CB2-7789" src="https://user-images.githubusercontent.com/104442665/226381540-a7455982-d081-4bed-b7a6-6fb824d9d268.PNG">


## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
