### PR TITLE
CB2-7793: Revert change to a previously deployed file

### DIFF
--- a/sql/00004_auth_into_service_table.sql
+++ b/sql/00004_auth_into_service_table.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset liquibase:create -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
-CREATE TABLE IF NOT EXISTS `auth_into_service` (
+CREATE TABLE `auth_into_service` (
   `id`                  bigint unsigned NOT NULL AUTO_INCREMENT,
   `technical_record_id` bigint unsigned NOT NULL,
   `cocIssueDate`        datetime DEFAULT NULL,


### PR DESCRIPTION
## Description

I forgot how liquibase works. This PR resets 00004_auth_into_service_table.sql back to how it was before it was deployed to the AWS environments.
![image](https://user-images.githubusercontent.com/13391709/229128525-267eec75-8956-4120-9a24-ae1bb41a76b5.png)
