### PR TITLE
Replaced logic in WHERE clause to use REGEXP instead of ID

### DIFF
--- a/sql/10001_tfl_views.sql
+++ b/sql/10001_tfl_views.sql
@@ -69,4 +69,4 @@ JOIN
     ON (fe.id = tr.fuel_emission_id)
 WHERE
     SUBSTR(tr.certificateNumber,1,2) IN ('LP', 'LF')
-    AND tt.id in (23, 29, 30, 31, 36, 38, 47, 81, 82, 132, 143, 158, 180, 196);
+    AND tt.testTypeName REGEXP '[[:<:]]LEC[[:>:]]|[[:<:]]Low Emissions Certificate[[:>:]]'


### PR DESCRIPTION
## Description

Minor change to use REGEXP in WHERE clause of tfl_view as ID field values are not the same across different environments

Related issue: [CB2-5043](https://dvsa.atlassian.net/browse/CB2-5043)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
