### PR TITLE
feat(CB2-8008): EVL Quick Fix

### DIFF
--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -11,6 +11,8 @@
     <include  file="sql/00004_auth_into_service_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00005_approval_region_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00006_alter_technical_record_table.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/00007_create_interim_fix_evl_tables.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>
     <include  file="referenceData/referenceData.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/sql/00007_create_interim_fix_evl_tables.sql
+++ b/sql/00007_create_interim_fix_evl_tables.sql
@@ -1,0 +1,53 @@
+--liquibase formatted sql
+--changeset liquibase:create -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+
+CREATE TABLE IF NOT EXISTS `vt_evl_00_cvs_system_numbers`
+(
+    `system_number`   VARCHAR(8)
+    ,PRIMARY KEY(`system_number`)
+)
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `vt_evl_01_static_set`
+(
+    `vrm`                   VARCHAR(20)
+    ,`vrm_test_record` 	    VARCHAR(20)
+    ,`system_number` 	    VARCHAR(8)
+    ,`vin`                  VARCHAR(21)
+    ,`certificateNumber`    VARCHAR(12)
+    ,`testStartDate`        DATETIME
+    ,`testExpiryDate`       DATETIME
+)
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `vt_evl_02_cvs_removed`
+(
+    `vrm`                   VARCHAR(20)
+    ,`vrm_test_record`      VARCHAR(20)
+    ,`system_number`        VARCHAR(8)
+    ,`vin`                  VARCHAR(21)
+    ,`certificateNumber`    VARCHAR(12)
+    ,`testStartDate`        DATETIME
+    ,`testExpiryDate`       DATETIME
+)
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `vt_evl_03_failures_removed`
+(
+    `vrm`                   VARCHAR(20)
+    ,`vrm_test_record`      VARCHAR(20)
+    ,`system_number`        VARCHAR(8)
+    ,`vin`                  VARCHAR(21)
+    ,`certificateNumber`    VARCHAR(12)
+    ,`testStartDate`        DATETIME
+    ,`testExpiryDate`       DATETIME
+)
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `vt_evl_additions`
+(
+    `vrm_trm`               VARCHAR(20)
+    ,`certificateNumber`    VARCHAR(12)
+    ,`testExpiryDate`       DATETIME
+)
+    ENGINE = InnoDB;

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,30 +1,51 @@
 --liquibase formatted sql
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev runOnChange:true
 CREATE OR REPLACE VIEW evl_view AS
-SELECT MAX(testExpiryDate) AS testExpiryDate,
-    SubQ.vrm_trm,
-    t.certificateNumber
-FROM test_result t
-    JOIN test_type tt ON t.test_type_id = tt.id
-    JOIN (
-        SELECT MAX(createdAt),
-            id,
+    SELECT 
+        MAX(testExpiryDate) AS testExpiryDate
+        ,vrm_trm
+        ,certificateNumber
+    FROM (
+        SELECT
+            SubQ.vrm_trm
+            ,t.certificateNumber
+            ,t.testExpiryDate
+        FROM test_result t
+        JOIN test_type tt ON t.test_type_id = tt.id
+        JOIN (
+            SELECT MAX(createdAt),
+                id
+                ,vrm_trm
+            FROM vehicle
+            WHERE 
+                LENGTH(vrm_trm) < 8
+                AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+            GROUP BY 
+                id
+                ,vrm_trm
+        ) SubQ ON SubQ.id = t.vehicle_id
+        WHERE 
+            t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
+            AND t.testStatus != 'cancelled'
+            AND tt.testTypeClassification = 'Annual With Certificate'
+            AND 
+                (
+                t.certificateNumber IS NOT NULL
+                AND t.certificateNumber != ''
+                AND NOT LOCATE(' ', t.certificateNumber) > 0
+                )
+        UNION ALL
+        SELECT
             vrm_trm
-        FROM vehicle
-        WHERE LENGTH(vrm_trm) < 8
-            AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-            AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-        GROUP BY id,
-            vrm_trm
-    ) SubQ ON SubQ.id = t.vehicle_id
-WHERE t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-    AND (
-        t.certificateNumber IS NOT NULL
-        AND t.certificateNumber != ''
-        AND NOT LOCATE(' ', t.certificateNumber) > 0
-    )
-    AND t.testStatus != 'cancelled'
-    AND tt.testTypeClassification = 'Annual With Certificate'
-GROUP BY SubQ.vrm_trm,
-    t.certificateNumber
-ORDER BY vrm_trm, testExpiryDate desc, t.testTypeEndTimeStamp desc;
+            ,certificateNumber
+            ,testExpiryDate
+        FROM vt_evl_additions
+    ) vt_cvs_union
+    GROUP BY
+        vrm_trm
+        ,certificateNumber
+    ORDER BY
+        vrm_trm
+        ,testExpiryDate DESC
+;

--- a/sql/20000_evl_temporary_tweak_sp.sql
+++ b/sql/20000_evl_temporary_tweak_sp.sql
@@ -1,0 +1,151 @@
+--liquibase formatted sql
+--changeset liquibase:3 splitStatements:true endDelimiter:// context:dev runOnChange:true
+
+DROP PROCEDURE IF EXISTS PrepareVTDataForEVL //
+CREATE DEFINER=CURRENT_USER PROCEDURE PrepareVTDataForEVL()
+/* 
+    Prepares valid test certificates from VT for combination with the CVS EVL
+    feed during the interim time period that data remediation work is ongoing.
+*/
+BEGIN
+	/* 
+        Get all the system numbers in CVS that have a valid certificate
+	    This will be used later as a way to exclude VT certificates for
+	    vehicles that already have one in CVS.
+    */
+	TRUNCATE `vt_evl_00_cvs_system_numbers`;
+	INSERT INTO `vt_evl_00_cvs_system_numbers`
+        SELECT 
+            v.`system_number`
+        FROM `test_result` AS t
+        JOIN `test_type` AS tt ON t.`test_type_id` = tt.`id`
+        JOIN `vehicle` AS v ON t.`vehicle_id` = v.`id`
+        WHERE 
+            t.`testExpiryDate` > DATE(NOW() - INTERVAL 3 DAY)
+            AND LOWER(t.`testStatus`) != 'cancelled'
+            AND LOWER(tt.`testTypeClassification`) = 'annual with certificate'
+            AND 
+            (
+                t.`certificateNumber` IS NOT NULL
+                AND t.`certificateNumber` != ''
+                AND NOT LOCATE(' ', t.`certificateNumber`) > 0
+            )
+        GROUP BY v.`system_number`
+	;
+
+    /*
+	    Get all of the valid certificates from VT, including extra
+	    information about the vehicle to be used for matching
+	    purposes.
+    */
+	TRUNCATE `vt_evl_01_static_set`;
+	INSERT INTO `vt_evl_01_static_set`
+        SELECT 
+            IFNULL(v.`CURR_REGMK`, v.`TRAILER_ID`)  AS vrm
+            ,vt.`VEHICLE_ID`                        AS vrm_test_record
+            ,v.`SYSTEM_NUMBER`                      AS system_number
+            ,v.`VIN`                                AS vin
+            ,vt.`TEST_CERTIFICATE_S`                AS certificateNumber
+            ,vt.`DATE0`                             AS testStartDate 
+            ,vt.`CERT_EXPIRY_DATE`                  AS testExpiryDate
+        FROM `VICP1DBA`.`VEHICLE_TEST` AS vt
+        JOIN `VICP1DBA`.`VEHICLE` AS v ON (vt.`FK_VEH_SYS_NUM` = v.`SYSTEM_NUMBER`)
+        JOIN `VICP1DBA`.`APPLICATION_TYPE` AS appl ON vt.`APPL_TYPE` = appl.`APPL_TYPE`
+        WHERE 
+            DATE(vt.`CERT_EXPIRY_DATE`) > NOW()
+            AND DATE(vt.`CERT_EXPIRY_DATE`) != '01-01-0001'
+            AND TRIM(vt.`TEST_CERTIFICATE_S`) <> ' '
+            AND TRIM(vt.`TEST_CERTIFICATE_S`) IS NOT NULL
+            AND NOT LOCATE(' ', vt.`TEST_CERTIFICATE_S`) > 0
+            AND 
+            (
+                -- From investigations into the legacy ETL codebase it seems
+                -- that these are commonly chosen as filters for "annual" tests
+                LOWER(appl.`APPL_TYPE`) IN ('aal','aas','aav','aat','rpv','rpt')
+                OR LOWER(appl.`DESC0`) LIKE '%annual%'
+            ) 
+            AND IFNULL(v.`CURR_REGMK`, v.`TRAILER_ID`) <> ' '
+            AND IFNULL(v.`CURR_REGMK`, v.`TRAILER_ID`) IS NOT NULL
+            AND LENGTH(IFNULL(v.`CURR_REGMK`, v.`TRAILER_ID`)) < 8
+            AND IFNULL(v.`CURR_REGMK`, v.`TRAILER_ID`) NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+            AND IFNULL(v.`CURR_REGMK`, v.`TRAILER_ID`) NOT REGEXP '^[0-9]{6}[zZ]$'
+	;
+
+	/*
+        Take the valid certificates from vt_evl_01_static_set that
+	    are assigned to system numbers that DO NOT have a valid
+	    certificate in CVS.
+	*/
+	TRUNCATE `vt_evl_02_cvs_removed`;
+	INSERT INTO `vt_evl_02_cvs_removed`
+        SELECT
+            vt.`vrm`
+            ,vt.`vrm_test_record`
+            ,vt.`system_number`
+            ,vt.`vin`
+            ,vt.`certificateNumber`
+            ,vt.`testStartDate`
+            ,vt.`testExpiryDate`
+        FROM `vt_evl_01_static_set` AS vt
+        LEFT JOIN `vt_evl_00_cvs_system_numbers` AS cvs ON vt.`system_number` = cvs.`system_number`
+        WHERE
+            cvs.`system_number` IS NULL
+            AND vt.`testExpiryDate` > DATE(NOW() - INTERVAL 3 DAY)
+	;
+
+	/*
+        Keep the certificates from vt_evl_02_cvs_removed that are
+	    assigned to system numbers that HAVE NOT had a failed annual
+	    test in CVS with a more recent test date.
+	*/
+	TRUNCATE `vt_evl_03_failures_removed`;
+	INSERT INTO `vt_evl_03_failures_removed` 
+        SELECT
+            vt.`vrm`
+            ,vt.`vrm_test_record`
+            ,vt.`system_number`
+            ,vt.`vin`
+            ,vt.`certificateNumber`
+            ,vt.`testStartDate`
+            ,vt.`testExpiryDate`
+        FROM `vt_evl_02_cvs_removed` AS vt
+        LEFT JOIN 
+        (
+            SELECT 
+                v.`system_number`
+                ,DATE(MAX(tr.`testTypeStartTimestamp`)) AS testTypeStartTimestamp
+            FROM `test_result` tr
+            JOIN `test_type` tt ON tr.`test_type_id` = tt.`id`
+            JOIN `vehicle` v ON tr.`vehicle_id` = v.`id`
+            WHERE 
+                LOWER(tr.`testResult`) = 'fail' 
+                AND LOWER(tt.`testTypeClassification`) = 'annual with certificate'
+                AND tr.`testTypeStartTimestamp` >= DATE(NOW() - INTERVAL 1 YEAR)
+            GROUP BY v.`system_number`
+        ) AS fails ON vt.`system_number` = fails.`system_number`
+        WHERE 
+            fails.`system_number` IS NULL OR fails.`testTypeStartTimestamp` < vt.`testStartDate`
+	;
+
+	/*
+        Insert only the fields required to the final table ready for union
+        with the CVS data in the evl_view. 
+        Final table (vt_evl_additions) has been excluded from the numbered naming
+        convention in case more processing steps are added in the future. Less rework
+        will be required.
+        This step should be used to apply any business rule logic deemed
+        appropriate.
+	*/
+	TRUNCATE `vt_evl_additions`;
+	INSERT INTO `vt_evl_additions` 
+        SELECT
+            vt.`vrm`
+            ,vt.`certificateNumber`
+            ,vt.`testExpiryDate`
+        FROM `vt_evl_03_failures_removed` AS vt
+	;
+    COMMIT;
+    
+END
+
+//


### PR DESCRIPTION
* feat(CB2-8008): adding sql script to create stored procedure that processes VT certificates and including in liquibase changelog.

* feat(CB2-8008): moving table creation statements into separate script, updating to create these tables in CVSNOP rather than UNMANAGED and altering some SP logic slightly to capture more annual tests

* fix(CB2-8008): removing schema specifications so that liquibase can run this in feature environments and also altering the delimiter specification for sproc

* fix(CB2-8008): changing sp creation to remove IF EXISTS, not valid in mysql 5.7 - instead attempting to DROP IF EXISTS first

* fix(CB2-8008): changing delimiter on DROP PROC to //

* feat(CB2-8008): adding final vt evl table with a SP step that can be used for business logic in future, currently none. Also updating evl_view to include the union with final vt table.

* fix(CB2-8008): adding LOWER() function to WHERE clauses that match on a string value

* fix(CB2-8008): updating system_number to varchar(8) in interim evl tables to be consistent with NOP

* fix(CB2-8008): adding a commit to the end of the SP in-case of any mysql non auto committing fun

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
