### PR TITLE
feat(CB2-8786): TfL feed to pick up LNV and LNZ tests

### DIFF
--- a/sql/10001_tfl_views.sql
+++ b/sql/10001_tfl_views.sql
@@ -61,19 +61,19 @@ SELECT
             NULL
     END AS IssueDateTime
 FROM 
-    CVSNOP.test_type tt
+    test_type tt
 JOIN
-    CVSNOP.test_result tr
+    test_result tr
     ON (tt.id = tr.test_type_id)
 JOIN
-    CVSNOP.vehicle v
+    vehicle v
     ON (v.id = tr.vehicle_id)
 JOIN
-    CVSNOP.test_station ts
+    test_station ts
     ON (ts.id = tr.test_station_id)
 JOIN
-    CVSNOP.fuel_emission fe
+    fuel_emission fe
     ON (fe.id = tr.fuel_emission_id)
 WHERE
     SUBSTR(tr.certificateNumber,1,2) = 'LP'
-    AND tt.testTypeName REGEXP '[[:<:]]LEC[[:>:]]|[[:<:]]Low Emissions Certificate[[:>:]]'
+    AND tr.testcode in ('lbp','lcp','ldv','lev','lez','lnp','lnv','lnz')


### PR DESCRIPTION
## Description

Update LEC test filter criteria to cover LNV and LNZ tests and look for a list of testCodes rather than REGEX matching for LEC/Low Emissions strings.

Went for this approach following Simon's analysis demonstrating that using the `testCode` list covers all tests that were previously being matched using the REGEX, and meant we didn't have to handle risky string matches for the new tests, or have two different sets of matching criteria. 

Related issue: [8786](https://dvsa.atlassian.net/browse/CB2-8786)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
