### PR TITLE
feat(CB2-8830): Body Make & Chassis Make Validation: extend from 20 char limit to 50

### DIFF
--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -12,6 +12,7 @@
     <include  file="sql/00005_approval_region_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00006_alter_technical_record_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00007_create_interim_fix_evl_tables.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/00008_alter_make_model_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10001_tfl_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>

--- a/sql/00008_alter_make_model_table.sql
+++ b/sql/00008_alter_make_model_table.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--changeset liquibase:modifyDataType -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+
+ALTER TABLE make_model MODIFY make VARCHAR(50), ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE make_model MODIFY chassisMake VARCHAR(50), ALGORITHM=INPLACE, LOCK=NONE;


### PR DESCRIPTION
## Description

Update max field length of `make` and `chassisMake` in `CVSNOP.make_model` table to allow for longer values coming in from VTM.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
