### PR TITLE
Updated logic to handle NULL modTypeCode

### DIFF
--- a/sql/10001_tfl_views.sql
+++ b/sql/10001_tfl_views.sql
@@ -5,7 +5,7 @@ SELECT
     v.vrm_trm as VRM,
     v.vin     as VIN,
     tr.certificateNumber as SerialNumberOfCertificate,
-    IFNULL(fe.modTypeCode,"") as CertificationModificationType,
+    IFNULL(fe.modTypeCode,"p") as CertificationModificationType,
     1 AS TestStatus,
     CASE IFNULL(fe.emissionStandard,"")
         WHEN 'Pre-Euro'                 THEN 1        


### PR DESCRIPTION
## Description

Updated logic in `tfl_view` to handle replace NULL `modTypeCode` with 'p' instead of an empty string

Related issue: [CB2-8967](https://dvsa.atlassian.net/browse/CB2-8967)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
