### PR TITLE
feature/CB2-11231 - Change the accepted maximum length of the Plate Serial Number in NOP

### DIFF
--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -13,6 +13,7 @@
     <include  file="sql/00006_alter_technical_record_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00007_create_interim_fix_evl_tables.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00008_alter_make_model_table.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/00009_alter_plateSerialNumber_field.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10001_tfl_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>

--- a/sql/00000_base_database.sql
+++ b/sql/00000_base_database.sql
@@ -328,7 +328,7 @@ CREATE TABLE IF NOT EXISTS `plate`
 (
     `id`                  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     `technical_record_id` BIGINT UNSIGNED NOT NULL,
-    `plateSerialNumber`   VARCHAR(12),
+    `plateSerialNumber`   VARCHAR(50),
     `plateIssueDate`      DATE,
     `plateReasonForIssue` VARCHAR(16),
     `plateIssuer`         VARCHAR(150),

--- a/sql/00000_base_database.sql
+++ b/sql/00000_base_database.sql
@@ -328,7 +328,7 @@ CREATE TABLE IF NOT EXISTS `plate`
 (
     `id`                  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     `technical_record_id` BIGINT UNSIGNED NOT NULL,
-    `plateSerialNumber`   VARCHAR(50),
+    `plateSerialNumber`   VARCHAR(12),
     `plateIssueDate`      DATE,
     `plateReasonForIssue` VARCHAR(16),
     `plateIssuer`         VARCHAR(150),

--- a/sql/00009_alter_plateSerialNumber_field.sql
+++ b/sql/00009_alter_plateSerialNumber_field.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--changeset liquibase:modifyDataType -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+
+ALTER TABLE plate MODIFY plateSerialNumber VARCHAR(50), ALGORITHM=INPLACE, LOCK=NONE;


### PR DESCRIPTION
## Description

Changes the accepted maximum length for the Plate Serial Number in NOP from 12 to 50

Related issue: [CB2-11231](https://dvsa.atlassian.net/browse/CB2-11231?atlOrigin=eyJpIjoiYmJmODZjNjhmMWNiNDljNDljZGYyZjI4N2QxZWNiZWEiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?

