### PR TITLE
Move window function and vrm-based deduplication into EVL view

### DIFF
--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -13,6 +13,7 @@
     <include  file="sql/00006_alter_technical_record_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00007_create_interim_fix_evl_tables.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00008_alter_make_model_table.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/00009_alter_plateSerialNumber_field.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10001_tfl_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>

--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -13,7 +13,6 @@
     <include  file="sql/00006_alter_technical_record_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00007_create_interim_fix_evl_tables.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00008_alter_make_model_table.sql" relativeToChangelogFile="true"/>
-    <include  file="sql/00009_alter_plateSerialNumber_field.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10001_tfl_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>

--- a/sql/00009_alter_plateSerialNumber_field.sql
+++ b/sql/00009_alter_plateSerialNumber_field.sql
@@ -1,4 +1,0 @@
---liquibase formatted sql
---changeset liquibase:modifyDataType -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
-
-ALTER TABLE plate MODIFY plateSerialNumber VARCHAR(50), ALGORITHM=INPLACE, LOCK=NONE;

--- a/sql/00009_alter_plateSerialNumber_field.sql
+++ b/sql/00009_alter_plateSerialNumber_field.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--changeset liquibase:modifyDataType -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+
+ALTER TABLE plate MODIFY plateSerialNumber VARCHAR(50), ALGORITHM=INPLACE, LOCK=NONE;

--- a/sql/10000_views.sql
+++ b/sql/10000_views.sql
@@ -1,51 +1,55 @@
 --liquibase formatted sql
 --changeset liquibase:3 -multiple-tables:1 splitStatements:true endDelimiter:; context:dev runOnChange:true
 CREATE OR REPLACE VIEW evl_view AS
-    SELECT 
-        MAX(testExpiryDate) AS testExpiryDate
-        ,vrm_trm
+    SELECT
+        vrm_trm
         ,certificateNumber
+        ,testExpiryDate
     FROM (
-        SELECT
-            SubQ.vrm_trm
-            ,t.certificateNumber
-            ,t.testExpiryDate
-        FROM test_result t
-        JOIN test_type tt ON t.test_type_id = tt.id
-        JOIN (
-            SELECT MAX(createdAt),
-                id
-                ,vrm_trm
-            FROM vehicle
-            WHERE 
-                LENGTH(vrm_trm) < 8
-                AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-                AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
-            GROUP BY 
-                id
-                ,vrm_trm
-        ) SubQ ON SubQ.id = t.vehicle_id
-        WHERE 
-            t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
-            AND t.testStatus != 'cancelled'
-            AND tt.testTypeClassification = 'Annual With Certificate'
-            AND 
-                (
-                t.certificateNumber IS NOT NULL
-                AND t.certificateNumber != ''
-                AND NOT LOCATE(' ', t.certificateNumber) > 0
-                )
-        UNION ALL
         SELECT
             vrm_trm
             ,certificateNumber
             ,testExpiryDate
-        FROM vt_evl_additions
-    ) vt_cvs_union
-    GROUP BY
-        vrm_trm
-        ,certificateNumber
+            ,ROW_NUMBER() OVER (PARTITION BY vrm_trm ORDER BY testExpiryDate DESC) AS rownumber
+        FROM (
+            SELECT
+                SubQ.vrm_trm
+                ,t.certificateNumber
+                ,t.testExpiryDate
+            FROM test_result t
+            JOIN test_type tt ON t.test_type_id = tt.id
+            JOIN (
+                SELECT MAX(createdAt),
+                    id
+                    ,vrm_trm
+                FROM vehicle
+                WHERE 
+                    LENGTH(vrm_trm) < 8
+                    AND vrm_trm NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                    AND vrm_trm NOT REGEXP '^[0-9]{6}[zZ]$'
+                GROUP BY 
+                    id
+                    ,vrm_trm
+            ) SubQ ON SubQ.id = t.vehicle_id
+            WHERE 
+                t.testExpiryDate > DATE(NOW() - INTERVAL 3 DAY)
+                AND t.testStatus != 'cancelled'
+                AND tt.testTypeClassification = 'Annual With Certificate'
+                AND 
+                    (
+                    t.certificateNumber IS NOT NULL
+                    AND t.certificateNumber != ''
+                    AND NOT LOCATE(' ', t.certificateNumber) > 0
+                    )
+            UNION ALL
+            SELECT
+                vrm_trm
+                ,certificateNumber
+                ,testExpiryDate
+            FROM vt_evl_additions
+        ) vt_cvs_union
+    ) windowed_evl_data
+    WHERE rownumber = 1
     ORDER BY
         vrm_trm
-        ,testExpiryDate DESC
 ;


### PR DESCRIPTION
## Description

EVL file generation is failing due to a collation issue introduced by a new mysql package version used by the enquiry service lambda. Whilst this could be resolved in the lambda, the fact that the lambda implements sql logic has always been a tech debt item. 

Using this opportunity to resolve the tech debt by moving that logic into the `evl_view` within NOP, which should also resolve the collation issue. 

Related issue: [CB2-12401](https://dvsa.atlassian.net/browse/CB2-12401)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
