### PR TITLE
Increase max length of variant number in NOP

### DIFF
--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -16,6 +16,7 @@
     <include  file="sql/00009_alter_plateSerialNumber_field.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00010_fix_auth_into_service_column_names.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00011_alter_test_result_add_vrm.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/00012_alter_variant_number_character.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10001_tfl_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>

--- a/sql/00012_alter_variant_number_character.sql
+++ b/sql/00012_alter_variant_number_character.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--changeset liquibase:change-variantNumber-length
+
+ALTER TABLE technical_record MODIFY COLUMN variantNumber VARCHAR(35);


### PR DESCRIPTION
## Description

<!--
The variant number in the Technical Records currently has a maximum length restriction of 25 characters. The Romans are looking to increase this limit to 35 characters. Script has been created to update NOP to allow up to 35 characters in the variant number field 
-->
Related issue: [CB2-18395](https://dvsa.atlassian.net/browse/CB2-18395)
Related issue: [CB2-18114](https://dvsa.atlassian.net/browse/CB2-18114)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [ x] Did you make sure to update any documentation relating to this change?


[CB2-18395]: https://dvsa.atlassian.net/browse/CB2-18395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB2-18114]: https://dvsa.atlassian.net/browse/CB2-18114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ