### PR TITLE
CB2-21653 - Increase limit of defect details notes on custom defect table on NOP

### DIFF
--- a/changelog-master.xml
+++ b/changelog-master.xml
@@ -17,6 +17,7 @@
     <include  file="sql/00010_fix_auth_into_service_column_names.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00011_alter_test_result_add_vrm.sql" relativeToChangelogFile="true"/>
     <include  file="sql/00012_alter_variant_number_character.sql" relativeToChangelogFile="true"/>
+    <include  file="sql/00014_alter_custom_defect_table.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10000_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/10001_tfl_views.sql" relativeToChangelogFile="true"/>
     <include  file="sql/20000_evl_temporary_tweak_sp.sql" relativeToChangelogFile="true"/>

--- a/sql/00014_alter_custom_defect_table.sql
+++ b/sql/00014_alter_custom_defect_table.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--changeset liquibase:modifyDataType -multiple-tables:1 splitStatements:true endDelimiter:; context:dev
+
+ALTER TABLE custom_defect MODIFY defectNotes VARCHAR(500), ALGORITHM=INPLACE, LOCK=NONE;


### PR DESCRIPTION
## Description
VTM and VTA are increasing the limit on the defect details notes field. This ticket is to ensure all relevant fields in NOP also support this limit.

### Include a summary of the change here.
added alteration sql file to liquibase

### Related issue: 
Jira ticket: [CB2-21653](https://dvsa.atlassian.net/browse/CB2-21653)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[CB2-21653]: https://dvsa.atlassian.net/browse/CB2-21653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ